### PR TITLE
Migrate from CreateSyntaxProvider() to ForAttributeWithMetadataName().

### DIFF
--- a/pkg/IDisposableGenerator/Directory.Build.props
+++ b/pkg/IDisposableGenerator/Directory.Build.props
@@ -6,7 +6,7 @@
     <Version>1.2.0</Version>
     <PackageReleaseNotes>Changes in this release:
 - Fixed bug in the KeepOpen dispose check in generated code.</PackageReleaseNotes>
-    <Copyright>Copyright (c) 2021~2025</Copyright>
+    <Copyright>Copyright (c) 2021~2026</Copyright>
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/IDisposableGenerator.CSharp/Directory.Build.props
+++ b/src/IDisposableGenerator.CSharp/Directory.Build.props
@@ -6,13 +6,14 @@
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
     <Version>1.2.0</Version>
-    <Copyright>Copyright (c) 2021~2025</Copyright>
+    <Copyright>Copyright (c) 2021~2026</Copyright>
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);NU5128;NU5127</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <AnalysisLevel>preview</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/IDisposableGenerator.CSharp/Directory.Packages.props
+++ b/src/IDisposableGenerator.CSharp/Directory.Packages.props
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../IDisposableGenerator/IDisposableGenerator.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- SourceLink -->

--- a/src/IDisposableGenerator.CSharp/IDisposableGenerator.cs
+++ b/src/IDisposableGenerator.CSharp/IDisposableGenerator.cs
@@ -5,10 +5,6 @@ using System.Text;
 [Generator]
 public class IDisposableGeneratorCS : IIncrementalGenerator
 {
-    private delegate void WriteDisposableCode(
-        WorkItemCollection workItemCollection,
-        ref SourceProductionContext context);
-
     // on MacOS add "SpinWait.SpinUntil(() => Debugger.IsAttached);" to debug in rider.
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {

--- a/src/IDisposableGenerator.VisualBasic/Directory.Build.props
+++ b/src/IDisposableGenerator.VisualBasic/Directory.Build.props
@@ -6,13 +6,14 @@
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
     <Version>1.2.0</Version>
-    <Copyright>Copyright (c) 2021~2025</Copyright>
+    <Copyright>Copyright (c) 2021~2026</Copyright>
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn);NU5128;NU5127</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <AnalysisLevel>preview</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/IDisposableGenerator.VisualBasic/Directory.Packages.props
+++ b/src/IDisposableGenerator.VisualBasic/Directory.Packages.props
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../IDisposableGenerator/IDisposableGenerator.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.0.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- SourceLink -->

--- a/src/IDisposableGenerator.VisualBasic/IDisposableGenerator.cs
+++ b/src/IDisposableGenerator.VisualBasic/IDisposableGenerator.cs
@@ -10,12 +10,12 @@ public class IDisposableGeneratorVB : IIncrementalGenerator
     {
         var workItemCollection = context.CompilationProvider.Select(
             static (_, _) => new WorkItemCollection(new VisualBasicGeneratedCodeWriter()));
-        SemanticHelper.RegisterSourceOutput<ClassBlockSyntax>(context, workItemCollection);
+        SemanticHelper.RegisterSourceOutput<ClassStatementSyntax>(context, workItemCollection);
         context.RegisterPostInitializationOutput(static ctx =>
         {
             // Always generate the attributes.
             var attributeSource = new StringBuilder();
-            _ = attributeSource.Append(Properties.Resources.AttributeCodeVisualBasic!);
+            _ = attributeSource.Append(Properties.Resources.AttributeCodeVisualBasic);
             attributeSource.ToSourceFile("GeneratedAttributes.g.vb", ref ctx);
         });
     }

--- a/src/IDisposableGenerator/Directory.Build.props
+++ b/src/IDisposableGenerator/Directory.Build.props
@@ -6,7 +6,7 @@
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
     <Version>1.2.0</Version>
-    <Copyright>Copyright (c) 2021~2025</Copyright>
+    <Copyright>Copyright (c) 2021~2026</Copyright>
     <!-- Special properties for analyzer packages. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>

--- a/src/IDisposableGenerator/Directory.Packages.props
+++ b/src/IDisposableGenerator/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <!-- SourceLink -->

--- a/src/IDisposableGenerator/SemanticHelper.cs
+++ b/src/IDisposableGenerator/SemanticHelper.cs
@@ -36,9 +36,10 @@ internal static class SemanticHelper
 
     public static void RegisterSourceOutput<T>(IncrementalGeneratorInitializationContext context, IncrementalValueProvider<WorkItemCollection> workItemCollection)
         => context.RegisterSourceOutput(
-            context.SyntaxProvider.CreateSyntaxProvider(
+            context.SyntaxProvider.ForAttributeWithMetadataName(
+                "IDisposableGenerator.GenerateDisposeAttribute",
                 static (n, _) => n is T,
-                static (n, ct) => (INamedTypeSymbol)n.SemanticModel.GetDeclaredSymbol(n.Node, ct)!)
+                static (ctx, _) => ctx.TargetSymbol as INamedTypeSymbol)
             .Collect().Combine(workItemCollection),
             static (ctx, items) =>
             {

--- a/src/IDisposableGenerator/WorkItemCollection.cs
+++ b/src/IDisposableGenerator/WorkItemCollection.cs
@@ -7,31 +7,18 @@ internal class WorkItemCollection(IGeneratedCodeWriter generatedCodeWriter)
 
     public int Count => this.WorkItems.Count;
 
-    public void Process(ImmutableArray<INamedTypeSymbol> testClasses, CancellationToken ct)
+    public void Process(ImmutableArray<INamedTypeSymbol?> testClasses, CancellationToken ct)
     {
         foreach (var testClass in testClasses)
         {
             ct.ThrowIfCancellationRequested();
-            var workItem = this.FindWithNamespace(testClass.FullNamespace());
-            if (workItem is null || !testClass.FullNamespace().Equals("IDisposableGenerator", StringComparison.Ordinal))
-            {
-                workItem = new WorkItem
+            var workItem = this.FindWithNamespace(testClass!.FullNamespace())
+                ?? new WorkItem
                 {
-                    Namespace = testClass.FullNamespace(),
+                    Namespace = testClass!.FullNamespace(),
                 };
-            }
             ct.ThrowIfCancellationRequested();
-
-            // Avoid a bug that would set namespace to "IDisposableGenerator"
-            // instead of the namespace that the WorkItem's classes are in.
-            if (testClass.FullNamespaceEquals("IDisposableGenerator"))
-            {
-                continue;
-            }
-
-            ct.ThrowIfCancellationRequested();
-            var classItem = GetClassItem(testClass);
-
+            var classItem = GetClassItem(testClass!);
             if (classItem is null)
             {
                 continue;
@@ -39,11 +26,9 @@ internal class WorkItemCollection(IGeneratedCodeWriter generatedCodeWriter)
 
             ct.ThrowIfCancellationRequested();
             workItem.Classes.Add(classItem);
-
             var memberQuery =
-                from member in testClass.GetMembers()
+                from member in testClass!.GetMembers()
                 select member;
-
             foreach (var member in memberQuery)
             {
                 ct.ThrowIfCancellationRequested();

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*-*" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="*-*" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing" Version="*-*" />
-    <PackageReference Include="xunit" Version="*-*" />
+    <PackageReference Include="xunit.v3.mtp-off" Version="*-*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="*-*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This fixes a few issues in the code:
- CreateSyntaxProvider() in most cases; ForAttributeWithMetadataName is quite literally (and tested) 100x faster than CSP.
- the transform from it should not return a syntax node or a symbol as it will a) ruin any ability to cache the transformation, and more importantly, b) it will keep Compilation references in memory unnecessarily long, meaning that in any IDE environment (VS, VS Code, Rider) the generator will cause massive memory bloat on developer machines.
- returned every single ClassDecorationSyntax in the compilation which required manual filtering of the namespaces to get the namespaces I want into WorkItems. With ForAttributeWithMetadataName the filtering was removed as it is not needed anymore.

# Checklist

- [x] I have read the Code of Conduct and the Contributing files before opening this issue.
- [x] I have verified the issue this pull request fixes or feature this pull request implements is to the current release.
- [x] I am using the latest stable release with the above code fix or the current main branch if code changes are present (prerelease code changes).
- [x] I have debugged and tested my changes before submitting this issue and that everything should just work.

## Describe the issue this fixes / feature this adds

<!-- A brief description of what this fixes or what this adds should be here. -->
